### PR TITLE
Upgrade to ng-packagr and partial compilation to support minor Ivy version changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ bundles/
 package/
 npm-debug.log
 node_modules/
-.angular
+.angular/
+.vs/
 
 example/dist/
 example/npm-debug.log

--- a/angular.json
+++ b/angular.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": false
+  },
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
@@ -96,7 +99,7 @@
       "prefix": "lib",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-ng-packagr:build",
+          "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "projects/lib/tsconfig.json",
             "project": "projects/lib/ng-package.json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^13.0.0",
-        "@angular-devkit/build-ng-packagr": "^0.1002.4",
         "@angular/cli": "^13.0.0",
         "@angular/compiler-cli": "^13.0.0",
         "@types/node": "^17.0.5",
@@ -233,97 +232,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@angular-devkit/build-ng-packagr": {
-      "version": "0.1002.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-ng-packagr/-/build-ng-packagr-0.1002.4.tgz",
-      "integrity": "sha512-+Cbx/6cO3etp6EtQuaMNJR6t+sEcD74qMtrVUY9VBOQ0NAATvDxhxAgboEnozdohOzCxH2EZIZq8OB1WBOOT5Q==",
-      "dev": true,
-      "dependencies": {
-        "@angular-devkit/architect": "0.1002.4",
-        "rxjs": "6.6.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": "^6.11.0 || ^7.5.6",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "ng-packagr": "^10.0.0",
-        "tsickle": "~0.39.0"
-      },
-      "peerDependenciesMeta": {
-        "tsickle": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular-devkit/build-ng-packagr/node_modules/@angular-devkit/architect": {
-      "version": "0.1002.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1002.4.tgz",
-      "integrity": "sha512-Vrb2XSnvqj4RByqSWPeG/o9BSNX2DL3pxwQgLMrxofG8/+1VHQ2MsN/KTxBnEZtqeW4/l2QWTsQyzY5frJI69A==",
-      "dev": true,
-      "dependencies": {
-        "@angular-devkit/core": "10.2.4",
-        "rxjs": "6.6.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": "^6.11.0 || ^7.5.6",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/build-ng-packagr/node_modules/@angular-devkit/core": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-10.2.4.tgz",
-      "integrity": "sha512-gnm/+Iyaa6Jt3E803bpTjkwDAIb0AhP9badaGwbx44+bhbNSE2WzOBmdsQrsxJXHAMEG9CGeBzeRd8XZtLACWg==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "6.12.4",
-        "fast-json-stable-stringify": "2.1.0",
-        "magic-string": "0.25.7",
-        "rxjs": "6.6.2",
-        "source-map": "0.7.3"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": "^6.11.0 || ^7.5.6",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/build-ng-packagr/node_modules/ajv": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@angular-devkit/build-ng-packagr/node_modules/rxjs": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-      "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@angular-devkit/build-ng-packagr/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
     },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.1301.2",
@@ -15643,68 +15551,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        }
-      }
-    },
-    "@angular-devkit/build-ng-packagr": {
-      "version": "0.1002.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-ng-packagr/-/build-ng-packagr-0.1002.4.tgz",
-      "integrity": "sha512-+Cbx/6cO3etp6EtQuaMNJR6t+sEcD74qMtrVUY9VBOQ0NAATvDxhxAgboEnozdohOzCxH2EZIZq8OB1WBOOT5Q==",
-      "dev": true,
-      "requires": {
-        "@angular-devkit/architect": "0.1002.4",
-        "rxjs": "6.6.2"
-      },
-      "dependencies": {
-        "@angular-devkit/architect": {
-          "version": "0.1002.4",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1002.4.tgz",
-          "integrity": "sha512-Vrb2XSnvqj4RByqSWPeG/o9BSNX2DL3pxwQgLMrxofG8/+1VHQ2MsN/KTxBnEZtqeW4/l2QWTsQyzY5frJI69A==",
-          "dev": true,
-          "requires": {
-            "@angular-devkit/core": "10.2.4",
-            "rxjs": "6.6.2"
-          }
-        },
-        "@angular-devkit/core": {
-          "version": "10.2.4",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-10.2.4.tgz",
-          "integrity": "sha512-gnm/+Iyaa6Jt3E803bpTjkwDAIb0AhP9badaGwbx44+bhbNSE2WzOBmdsQrsxJXHAMEG9CGeBzeRd8XZtLACWg==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.12.4",
-            "fast-json-stable-stringify": "2.1.0",
-            "magic-string": "0.25.7",
-            "rxjs": "6.6.2",
-            "source-map": "0.7.3"
-          }
-        },
-        "ajv": {
-          "version": "6.12.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "rxjs": {
-          "version": "6.6.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-          "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^13.0.0",
-    "@angular-devkit/build-ng-packagr": "^0.1002.4",
     "@angular/cli": "^13.0.0",
     "@angular/compiler-cli": "^13.0.0",
     "@types/node": "^17.0.5",

--- a/projects/lib/tsconfig.json
+++ b/projects/lib/tsconfig.json
@@ -14,7 +14,8 @@
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "enableResourceInlining": true
+    "enableResourceInlining": true,
+    "compilationMode": "partial"
   },
   "exclude": [
     "src/test.ts",


### PR DESCRIPTION
Hi @magnusbakken ,

I made this small change to your PR to solve the incompatibility issue:
@angular-devkit/build-ng-packagr is deprecated, this small change switches lib compilation to ng-packagr.
Also changed the compilationMode to partial, which is the recomended mode for libs in Ivy published to npm see:
[ng-packagr](https://angular.io/guide/creating-libraries#ensuring-library-version-compatibility)